### PR TITLE
Fix issue with b64decode if JWT contains UTF-8 Characters

### DIFF
--- a/py_jwt_verifier/jwk/__init__.py
+++ b/py_jwt_verifier/jwk/__init__.py
@@ -53,7 +53,7 @@ class JWK:
         except JSONDecodeError:
             raise self.py_jwt_exception("json")
         for key in keys:
-            print(key)
+            # print(key)
             if kid == key.get("kid"):
                 e = key.get("e")
                 n = key.get("n")

--- a/py_jwt_verifier/jwk/__init__.py
+++ b/py_jwt_verifier/jwk/__init__.py
@@ -53,7 +53,6 @@ class JWK:
         except JSONDecodeError:
             raise self.py_jwt_exception("json")
         for key in keys:
-            # print(key)
             if kid == key.get("kid"):
                 e = key.get("e")
                 n = key.get("n")

--- a/py_jwt_verifier/jwk/__init__.py
+++ b/py_jwt_verifier/jwk/__init__.py
@@ -22,7 +22,7 @@ class JWK:
         self.cache_store = cache_store
         if cache_enabled:
             try:
-                requests_cache.install_cache(expire_after=self.cache_lifetime, backend=self.cache_store, connection=cache_store_connection)   
+                requests_cache.install_cache(expire_after=self.cache_lifetime, backend=self.cache_store)   
                 requests_cache.remove_expired_responses()
             except ValueError:
                 raise self.py_jwt_exception("cache-store")

--- a/py_jwt_verifier/utils/__init__.py
+++ b/py_jwt_verifier/utils/__init__.py
@@ -21,7 +21,11 @@ class Utils:
         decoded_jwt = []
         for part in _jwt:
             part += self.compute_padding(part)
-            decoded_jwt.append(loads(b64decode(part)))
+            try:
+              decoded_jwt.append(loads(b64decode(part)))
+            except Exception as e:
+              print('Basic decode failed, using urlsafe b64decode')
+              decoded_jwt.append(loads(urlsafe_b64decode(part)))
         return decoded_jwt
 
     def intarr2long(self, arr):


### PR DESCRIPTION
In certain cases, for instance using Single Sign On with Google, the resulting jwt can contain non-ascii characters. b64decode then fails with an Exception. Retrying with urlsafe_b64decode seems to work