### PR TITLE
Added specific JSON Decode error exception

### DIFF
--- a/py_jwt_verifier/jwk/__init__.py
+++ b/py_jwt_verifier/jwk/__init__.py
@@ -30,9 +30,11 @@ class JWK:
     def get_json_response(self, url):
         try:
             response = requests.get(url)
+            json_response = response.json()
         except SSLError:
             raise self.py_jwt_exception("ssl")
-        json_response = response.json()
+        except JSONDecodeError:
+            raise self.py_jwt_exception("json")
         return json_response
     
     def compute_keys_endpoint(self, issuer):


### PR DESCRIPTION
This happens when the tfp claim is empty or invalid and it might result in an incorrect URL for openid-configuration. This would the return a 404 and if parsed bubbles up an error saying `Expecting value: line 1 column 1 (char 0)` on the `json()` call on the response.
Catching the JSONDecode error is more specific and highlights potential underlying root cause better.