### PR TITLE
adds support for base64 urlencoded JWT

### DIFF
--- a/py_jwt_verifier/utils/__init__.py
+++ b/py_jwt_verifier/utils/__init__.py
@@ -20,6 +20,8 @@ class Utils:
         _jwt = jwt[0:2] #Removing signature [2]
         decoded_jwt = []
         for part in _jwt:
+            part = part.replace('_', '/')
+            part = part.replace('-', '+')
             part += self.compute_padding(part)
             decoded_jwt.append(loads(b64decode(part)))
         return decoded_jwt


### PR DESCRIPTION
Some OIDC provider deliver a JWT in base64 urlencoded format.
This PR adds support for urlencoded base64 when decoding the JWT content but still preserving the signature verification.